### PR TITLE
Fix Foundry v11 compatibility

### DIFF
--- a/scripts/dnd5e.mjs
+++ b/scripts/dnd5e.mjs
@@ -80,7 +80,7 @@ export default class Dnd5e {
         if (selectedEnvironments?.length > 0) {
             availableActors = availableActors.filter(x => {
                 if (x.system?.details?.environment != undefined) {
-                    return selectedEnvironments.filter(value => x.details.environment.includes(value)).length > 0;
+                    return selectedEnvironments.filter(value => x.system.details.environment.includes(value)).length > 0;
                 }
                 return false;
             });

--- a/scripts/dnd5e.mjs
+++ b/scripts/dnd5e.mjs
@@ -16,8 +16,8 @@ export default class Dnd5e {
     initValuesFromAllActors(allActors) {
         let environments = new Set();
         allActors.forEach(actor => {
-            if (actor.data?.data?.details?.environment) {
-                environments.add(actor.data?.data?.details?.environment);
+            if (actor.system?.details?.environment) {
+                environments.add(actor.system?.details?.environment);
             }
         });
         this.environments = Array.from(environments);
@@ -38,11 +38,11 @@ export default class Dnd5e {
     }
 
     getPlayerCharacters() {
-        return game.actors.filter((x) => x.hasPlayerOwner && x.data.type == "character");
+        return game.actors.filter((x) => x.hasPlayerOwner && x.type == "character");
     }
 
     getNpcs() {
-        return game.actors.filter((x) => x.data.type == "npc" && !x.data.img.includes("baileywiki"));
+        return game.actors.filter((x) => x.type == "npc" && !x.img.includes("baileywiki"));
     }
 
     filterCompendiumActors(pack, packActors) {
@@ -74,13 +74,13 @@ export default class Dnd5e {
         }
 
         if (!!selectedName) {
-            availableActors = availableActors.filter(x => x.data.name.toLowerCase().includes(selectedName.toLowerCase()));
+            availableActors = availableActors.filter(x => x.name.toLowerCase().includes(selectedName.toLowerCase()));
         }
 
         if (selectedEnvironments?.length > 0) {
             availableActors = availableActors.filter(x => {
-                if (x.data.data?.details?.environment != undefined) {
-                    return selectedEnvironments.filter(value => x.data.data.details.environment.includes(value)).length > 0;
+                if (x.system?.details?.environment != undefined) {
+                    return selectedEnvironments.filter(value => x.details.environment.includes(value)).length > 0;
                 }
                 return false;
             });
@@ -88,8 +88,8 @@ export default class Dnd5e {
 
         if (selectedTypes?.length > 0) {
             availableActors = availableActors.filter(x => {
-                if (x.data.data?.details?.type != undefined) {
-                    return selectedTypes.filter(value => x.data.data.details.type.value == value).length > 0;
+                if (x.system?.details?.type != undefined) {
+                    return selectedTypes.filter(value => x.system.details.type.value == value).length > 0;
                 }
                 return false;
             });
@@ -97,9 +97,9 @@ export default class Dnd5e {
 
         if (selectedSizes?.length > 0) {
             availableActors = availableActors.filter(x => {
-                if (x.data.data?.traits?.size != undefined) {
+                if (x.system?.traits?.size != undefined) {
                     return selectedSizes.filter(value =>
-                        Object.entries(CONFIG.DND5E.actorSizes).find(x => x[1] == value)[0] == x.data.data.traits.size
+                        Object.entries(CONFIG.DND5E.actorSizes).find(x => x[1] == value)[0] == x.system.traits.size
                     ).length > 0;
                 }
                 return false;
@@ -108,7 +108,7 @@ export default class Dnd5e {
 
         if (selectedAlignmentsLaw?.length || selectedAlignmentsGood?.length) {
             availableActors = availableActors.filter(x => {
-                const alignment = x.data.data.details.alignment.toLowerCase();
+                const alignment = x.system.details.alignment.toLowerCase();
 
                 if (alignment === 'unaligned') {
                     return false;
@@ -141,14 +141,14 @@ export default class Dnd5e {
 
         if (selectedMovements?.length > 0) {
             availableActors = availableActors.filter(x => {
-                if (x.data.data?.attributes?.movement != undefined) {
+                if (x.system?.attributes?.movement != undefined) {
                     let matchingMovements = selectedMovements.filter(value => {
                         switch (value) {
-                            case "Burrows": return x.data.data.attributes.movement.burrow > 0;
-                            case "Climbs": return x.data.data.attributes.movement.climb > 0;
-                            case "Flys": return x.data.data.attributes.movement.fly > 0;
-                            case "Swims": return x.data.data.attributes.movement.swim > 0;
-                            case "Walks": return x.data.data.attributes.movement.walk > 0;
+                            case "Burrows": return x.system.attributes.movement.burrow > 0;
+                            case "Climbs": return x.system.attributes.movement.climb > 0;
+                            case "Flys": return x.system.attributes.movement.fly > 0;
+                            case "Swims": return x.system.attributes.movement.swim > 0;
+                            case "Walks": return x.system.attributes.movement.walk > 0;
                         }
                     });
                     return matchingMovements.length > 0;
@@ -159,12 +159,12 @@ export default class Dnd5e {
 
         if (selectedTraits?.length > 0) {
             availableActors = availableActors.filter(x => {
-                if (x.data.data != undefined) {
+                if (x.system != undefined) {
                     let matchingTraits = selectedTraits.filter(value => {
                         switch (value) {
-                            case "Spellcaster": return x.data.data.details.spellLevel > 0;
-                            case "Lair Actions": return x.data.data.resources?.lair?.value;
-                            case "Legendary Actions": return x.data.data.resources?.legact?.max > 0 || x.data.data.resources?.legres?.max > 0;
+                            case "Spellcaster": return x.system.details.spellLevel > 0;
+                            case "Lair Actions": return x.system.resources?.lair?.value;
+                            case "Legendary Actions": return x.system.resources?.legact?.max > 0 || x.system.resources?.legres?.max > 0;
                         }
                     });
                     return matchingTraits.length > 0;
@@ -175,8 +175,8 @@ export default class Dnd5e {
 
         if (selectedResistances?.length > 0) {
             availableActors = availableActors.filter(x => {
-                if (x.data.data?.traits?.dr != undefined) {
-                    return selectedResistances.filter(value => x.data.data.traits.dr.value.includes(value)).length > 0;
+                if (x.system?.traits?.dr != undefined) {
+                    return selectedResistances.filter(value => x.system.traits.dr.value.includes(value)).length > 0;
                 }
                 return false;
             });
@@ -184,8 +184,8 @@ export default class Dnd5e {
 
         if (selectedImmunities?.length > 0) {
             availableActors = availableActors.filter(x => {
-                if (x.data.data?.traits?.di != undefined) {
-                    return selectedImmunities.filter(value => x.data.data.traits.di.value.includes(value)).length > 0;
+                if (x.system?.traits?.di != undefined) {
+                    return selectedImmunities.filter(value => x.system.traits.di.value.includes(value)).length > 0;
                 }
                 return false;
             });
@@ -193,8 +193,8 @@ export default class Dnd5e {
 
         if (selectedVulnerabilities?.length > 0) {
             availableActors = availableActors.filter(x => {
-                if (x.data.data?.traits?.dv != undefined) {
-                    return selectedVulnerabilities.filter(value => x.data.data.traits.dv.value.includes(value)).length > 0;
+                if (x.system?.traits?.dv != undefined) {
+                    return selectedVulnerabilities.filter(value => x.system.traits.dv.value.includes(value)).length > 0;
                 }
                 return false;
             });
@@ -204,12 +204,12 @@ export default class Dnd5e {
     }
 
     getActorSource(actor, skipDetails) {
-        if (actor.data.data.details.source && !skipDetails) {
-            return actor.data.data.details.source.split('pg')[0];
+        if (actor.system.details.source && !skipDetails) {
+            return actor.system.details.source.split('pg')[0];
         }
 
         let nonCompendiumSourceType = game.settings.get("vue-encounter-builder", "nonCompendiumSourceType");
-        let source = game.world.data.title;
+        let source = game.world.title;
 
         if (nonCompendiumSourceType == "folderName") {
             if (actor.folder != undefined) {
@@ -228,7 +228,7 @@ export default class Dnd5e {
     getEncounterScore(actor) {
         if (actor == undefined) return -30;
         try {
-            return actor.data.data.details.xp.value;
+            return actor.system.details.xp.value;
         }
         catch (error) {
             console.error(error);
@@ -237,14 +237,14 @@ export default class Dnd5e {
     }
 
     getSafeLevel(actor) {
-        if (actor.data.type == "character") {
-            if (actor.data?.data?.details?.level) {
-                return Number(actor.data.data.details.level);
+        if (actor.type == "character") {
+            if (actor.system?.details?.level) {
+                return Number(actor.system.details.level);
             }
         }
         else {
-            if (actor.data?.data?.details?.cr) {
-                return Number(actor.data.data.details.cr);
+            if (actor.system?.details?.cr) {
+                return Number(actor.system.details.cr);
             }
         }
         return 0;

--- a/scripts/pf2e.mjs
+++ b/scripts/pf2e.mjs
@@ -25,11 +25,11 @@ export default class Pathfinder2E {
     histogramLabelPrettify(level) { return level; }
 
     getPlayerCharacters() {
-        return game.actors.filter((x) => x.hasPlayerOwner && x.data.type == "character");
+        return game.actors.filter((x) => x.hasPlayerOwner && x.type == "character");
     }
 
     getNpcs() {
-        return game.actors.filter((x) => x.data.type == "npc" || x.data.type == "hazard");
+        return game.actors.filter((x) => x.type == "npc" || x.type == "hazard");
     }
 
     filterCompendiumActors(pack, packActors) {
@@ -48,38 +48,38 @@ export default class Pathfinder2E {
             availableActors = availableActors.filter(x => selectedSources.includes(this.getActorSource(x).toLowerCase()));
         }
         if (selectedName != "") {
-            availableActors = availableActors.filter(x => x.data.name.toLowerCase().includes(selectedName.toLowerCase()));
+            availableActors = availableActors.filter(x => x.name.toLowerCase().includes(selectedName.toLowerCase()));
         }
 
         if (selectedAlignments?.length) {
-            availableActors = availableActors.filter(x => selectedAlignments.includes(x.data.data?.details?.alignments?.value));
+            availableActors = availableActors.filter(x => selectedAlignments.includes(x.system?.details?.alignments?.value));
         }
 
         if (selectedTraits?.length) {
             availableActors = availableActors.filter(x => {
-                return !!x.data.data?.traits?.traits?.value.some(trait => selectedTraits.includes(trait));
+                return !!x.system?.traits?.traits?.value.some(trait => selectedTraits.includes(trait));
             });
         }
 
         if (selectedRarities?.length) {
-            availableActors = availableActors.filter(x => selectedRarities.includes(x.data.data.traits?.rarity?.value));
+            availableActors = availableActors.filter(x => selectedRarities.includes(x.system.traits?.rarity?.value));
         }
 
         if (selectedSizes?.length) {
-            availableActors = availableActors.filter(x => selectedSizes.includes(x.data.data.traits?.size?.value));
+            availableActors = availableActors.filter(x => selectedSizes.includes(x.system.traits?.size?.value));
         }
 
         return availableActors;
     }
 
     getActorSource(actor, skipDetails) {
-        if (actor.data.data.details.source?.value && !skipDetails) {
-            return actor.data.data.details.source.value;
+        if (actor.system.details.source?.value && !skipDetails) {
+            return actor.system.details.source.value;
         }
 
         //log(false, actor.name);
         let nonCompendiumSourceType = game.settings.get("vue-encounter-builder", "nonCompendiumSourceType");
-        let source = game.world.data.title;
+        let source = game.world.title;
 
         if (nonCompendiumSourceType == "folderName") {
             if (actor.folder != undefined) {
@@ -99,7 +99,7 @@ export default class Pathfinder2E {
         if (actor == undefined) return -30;
         //log(false, actor);
         try {
-            if (actor.data.type == "hazard") {
+            if (actor.type == "hazard") {
                 let simpleChart = [
                     2,
                     3,
@@ -124,7 +124,7 @@ export default class Pathfinder2E {
                     150
                 ];
 
-                let xpChart = actor.data.data.details.isComplex ? complexChart : simpleChart;
+                let xpChart = actor.system.details.isComplex ? complexChart : simpleChart;
 
                 let levelDifference = this.getSafeLevel(actor) - partyInfo.averagePartyLevel;
                 let xpIndex = levelDifference + 4;
@@ -157,9 +157,9 @@ export default class Pathfinder2E {
     }
 
     getSafeLevel(actor) {
-        if (actor?.data?.data?.details?.level) {
-            if (actor.data.data.details.level?.value) return actor.data.data.details.level.value;
-            return actor.data.data.details.level;
+        if (actor?.system?.details?.level) {
+            if (actor.system.details.level?.value) return actor.system.details.level.value;
+            return actor.system.details.level;
         }
         return 0;
     }

--- a/scripts/thirteenth-age.mjs
+++ b/scripts/thirteenth-age.mjs
@@ -11,11 +11,11 @@ export default class ThirteenthAge {
     histogramLabelPrettify(level) { return level; }
 
     getPlayerCharacters() {
-        return game.actors.filter((x) => x.hasPlayerOwner && x.data.type == "character");
+        return game.actors.filter((x) => x.hasPlayerOwner && x.type == "character");
     }
 
     getNpcs() {
-        return game.actors.filter((x) => x.data.type == "npc");
+        return game.actors.filter((x) => x.type == "npc");
     }
 
     filterCompendiumActors(pack, packActors) {
@@ -66,7 +66,7 @@ export default class ThirteenthAge {
     getActorSource(actor) {
         //console.log(actor.name);
         let nonCompendiumSourceType = game.settings.get("vue-encounter-builder", "nonCompendiumSourceType");
-        let source = game.world.data.title;
+        let source = game.world.title;
 
         if (nonCompendiumSourceType == "folderName") {
             if (actor.folder != undefined) {

--- a/vue/EncounterBuilder.vue
+++ b/vue/EncounterBuilder.vue
@@ -355,8 +355,8 @@ export default {
         (a, b) => {
           const aLevel = this.system.getSafeLevel(a);
           const bLevel = this.system.getSafeLevel(b);
-          const aName = a.data.name;
-          const bName = b.data.name;
+          const aName = a.name;
+          const bName = b.name;
 
           switch (true) {
             // if both levels are the same, sort by name
@@ -394,9 +394,9 @@ export default {
 
       // if (this.sortNameAsc != undefined) {
       //   if (this.sortNameAsc) {
-      //     availableActors.sort((a, b) => (a.data.name > b.data.name ? 1 : -1));
+      //     availableActors.sort((a, b) => (a.name > b.name ? 1 : -1));
       //   } else {
-      //     availableActors.sort((a, b) => (a.data.name < b.data.name ? 1 : -1));
+      //     availableActors.sort((a, b) => (a.name < b.name ? 1 : -1));
       //   }
       // }
 
@@ -431,7 +431,7 @@ export default {
       for (let x = 0; x < this.selectedActors.length; x++) {
         let selected = this.selectedActors[x];
         //this.log(false, selected);
-        let name = selected.data.name;
+        let name = selected.name;
         if (!(name in grouped)) {
           grouped[name] = [];
         }
@@ -510,7 +510,7 @@ export default {
 
     let npcs = this.system.getNpcs();
     let allActors = npcs;
-    this.sources.push(game.world.data.title);
+    this.sources.push(game.world.title);
     let actorCompendiums = Array.from(game.packs.entries()).filter(
       (x) => x[1].metadata.type == "Actor" && !x[1].metadata.name.includes("baileywiki")
     );

--- a/vue/components/13th-age/thirteenth-age-actor.vue
+++ b/vue/components/13th-age/thirteenth-age-actor.vue
@@ -3,32 +3,32 @@
     <div class="actor-listing-contents" v-on:click.left="$emit('add-actor')"  v-on:click.right="$emit('remove-actor')">
 
     <div class="actor-image">
-      <img :src="actor.data.img" width="100" height="100" />
+      <img :src="actor.img" width="100" height="100" />
     </div>
     
     <section class="actor-info">
       <h4 class="name">
-        <span class="level" v-if="actor.data.data.details?.level?.value"
-          >[{{ actor.data.data.details.level.value }}]</span
+        <span class="level" v-if="actor.system.details?.level?.value"
+          >[{{ actor.system.details.level.value }}]</span
         >
-        {{ actor.data.name }}
+        {{ actor.name }}
       </h4>
 
       <dl class="trait-list">
         <div
           is="actor-trait"
           :label="'Size'"
-          :value="actor.data.data.details?.size?.value"></div>
+          :value="actor.system.details?.size?.value"></div>
           
         <div
           is="actor-trait"
           :label="'Role'"
-          :value="actor.data.data.details?.role?.value"></div>
+          :value="actor.system.details?.role?.value"></div>
           
         <div
           is="actor-trait"
           :label="'Type'"
-          :value="actor.data.data.details?.type?.value"></div>
+          :value="actor.system.details?.type?.value"></div>
 
         <div
           is="actor-trait"

--- a/vue/components/13th-age/thirteenth-age-selected-actor.vue
+++ b/vue/components/13th-age/thirteenth-age-selected-actor.vue
@@ -7,7 +7,7 @@
       v-on:click.left="$emit('add-actor')"
       v-on:click.right="$emit('remove-actor')">
       <div class="actor-image">
-        <img :src="actor.data.img" />
+        <img :src="actor.img" />
       </div>
 
       <div class="member-details">

--- a/vue/components/dnd5e/dnd5e-actor.vue
+++ b/vue/components/dnd5e/dnd5e-actor.vue
@@ -3,11 +3,11 @@
     <div class="actor-listing-contents" v-on:click.left="$emit('add-actor')"  v-on:click.right="$emit('remove-actor')">
       <section class="actor-info">
         <h4 class="name">
-          {{ actor.data.name }}
+          {{ actor.name }}
         </h4>
 
         <em class="trait-value">
-            {{actorSizes[actor.data.data.traits.size]}} {{ actor.labels.creatureType }}
+            {{actorSizes[actor.system.traits.size]}} {{ actor.labels.creatureType }}
         </em>
 
         <hr />
@@ -16,7 +16,7 @@
           <div
             is="actor-trait"
             :label="'Challenge'"
-            :value="`${system.histogramLabelPrettify(actor.data.data.details.cr)}   (${actor.encounterScore} XP)`"></div>
+            :value="`${system.histogramLabelPrettify(actor.system.details.cr)}   (${actor.encounterScore} XP)`"></div>
         </dl>
 
         <ul class="tags">
@@ -24,11 +24,11 @@
             :key="tag">{{tag}}</li>
         </ul>
 
-        <small class="actor-source">{{ actor.data.data.details.source }}</small>
+        <small class="actor-source">{{ actor.system.details.source }}</small>
       </section>
 
-      <div class="actor-image" v-if="actor.data.img !== 'icons/svg/mystery-man.svg'">
-        <img :src="actor.data.img" />
+      <div class="actor-image" v-if="actor.img !== 'icons/svg/mystery-man.svg'">
+        <img :src="actor.img" />
       </div>
     </div>
 
@@ -54,7 +54,7 @@ export default {
   },
   computed: {
     tags() {
-      const {attributes, details, resources} = this.actor.data.data;
+      const {attributes, details, resources} = this.actor.system;
       const ret = [];
 
 

--- a/vue/components/dnd5e/dnd5e-selected-actor.vue
+++ b/vue/components/dnd5e/dnd5e-selected-actor.vue
@@ -7,7 +7,7 @@
       v-on:click.left="$emit('add-actor')"
       v-on:click.right="$emit('remove-actor')">
       <div class="actor-image">
-        <img :src="actor.data.img" />
+        <img :src="actor.img" />
       </div>
 
       <div class="member-details">

--- a/vue/components/pf2e/pf2e-actor.vue
+++ b/vue/components/pf2e/pf2e-actor.vue
@@ -2,14 +2,14 @@
   <li class="actor-listing">
     <div class="actor-listing-contents" v-on:click.left="$emit('add-actor')"  v-on:click.right="$emit('remove-actor')">
       <div class="actor-image">
-        <img :src="actor.data.img" width="100" height="100" />
+        <img :src="actor.img" width="100" height="100" />
       </div>
       <section class="actor-info">
         <h4 class="name">
-          <span class="level" v-if="actor.data.data.details?.level?.value"
-            >[{{ actor.data.data.details.level.value }}]</span
+          <span class="level" v-if="actor.system.details?.level?.value"
+            >[{{ actor.system.details.level.value }}]</span
           >
-          {{ actor.data.name }}
+          {{ actor.name }}
         </h4>
 
 
@@ -48,7 +48,7 @@ export default {
   props: ["actor"],
   computed: {
     primaryTags() {
-      const {traits, details} = this.actor.data.data;
+      const {traits, details} = this.actor.system;
       const ret = [];
 
       if (!!traits?.rarity?.value) {
@@ -66,7 +66,7 @@ export default {
       return ret;
     },
     tags() {
-      return this.actor.data.data?.traits?.traits?.value
+      return this.actor.system?.traits?.traits?.value
         .map((tag) => game.i18n.localize(CONFIG.PF2E.monsterTraits[tag]))
         .filter((tag) => !!tag)
     },

--- a/vue/components/pf2e/pf2e-selected-actor.vue
+++ b/vue/components/pf2e/pf2e-selected-actor.vue
@@ -7,7 +7,7 @@
       v-on:click.left="$emit('add-actor')"
       v-on:click.right="$emit('remove-actor')">
       <div class="actor-image">
-        <img :src="actor.data.img" />
+        <img :src="actor.img" />
       </div>
         
       <div class="member-details">


### PR DESCRIPTION
I updated all reference to the v10 (and before) data model in the actors to use the v11 data model, because when the module tries to load the SRD monster compendium (my system of reference is 13th Age, but it was the same for PF2 and D&D 5e), the hundreds and hundreds of deprecation warning messages were making the module laggy.