### PR TITLE
Swap (now defunct) Warpgate for Portal to spawn monsters, and other fixes for v12

### DIFF
--- a/module.json
+++ b/module.json
@@ -21,13 +21,22 @@
   "relationships": {
     "systems": [
       {
-        "id": "archmage"
+        "id": "archmage",
+        "compatibility": {
+          "verified": "1.30.2"
+        }
       },
       {
-        "id": "pf2e"
+        "id": "pf2e",
+        "compatibility": {
+          "verified": "6.0.4"
+        }
       },
       {
-        "id": "dnd5e"
+        "id": "dnd5e",
+        "compatibility": {
+          "verified": "3.2.1"
+        }
       }
     ],
     "requires": [
@@ -45,13 +54,9 @@
       }
     ]
   },
-  "esmodules": [
-    "/scripts/module.js"
-  ],
+  "esmodules": ["/scripts/module.js"],
   "scripts": [],
-  "styles": [
-    "/css/module.css"
-  ],
+  "styles": ["/css/module.css"],
   "languages": [
     {
       "lang": "en",

--- a/module.json
+++ b/module.json
@@ -40,7 +40,7 @@
         "type": "module"
       },
       {
-        "id": "warpgate",
+        "id": "portal-lib",
         "type": "module"
       }
     ]

--- a/scripts/dnd5e.mjs
+++ b/scripts/dnd5e.mjs
@@ -5,12 +5,12 @@ export default class Dnd5e {
     constructor() {
         this.environments = [];
         this.creatureTypes = Object.keys(CONFIG.DND5E.creatureTypes).map((x) => ({
-            label: game.i18n.localize(CONFIG.DND5E.creatureTypes[x]),
+            label: game.i18n.localize(`DND5E.Creature${x.charAt(0).toUpperCase()}${x.slice(1)}`),
             value: x,
         }));
-        this.actorSizes = Object.values(CONFIG.DND5E.actorSizes).reverse();
-        this.damageResistanceTypes = Object.values(CONFIG.DND5E.damageResistanceTypes);
-        this.movementTypes = Object.keys(CONFIG.DND5E.movementTypes);
+        this.actorSizes = Object.values(CONFIG.DND5E.actorSizes).map(x => x.label);
+        this.damageResistanceTypes = Object.values(CONFIG.DND5E.damageTypes).map(x => x.label);
+        this.movementTypes = Object.values(CONFIG.DND5E.movementTypes);
     }
 
     initValuesFromAllActors(allActors) {
@@ -101,7 +101,7 @@ export default class Dnd5e {
             availableActors = availableActors.filter(x => {
                 if (x.system?.traits?.size != undefined) {
                     return selectedSizes.filter(value =>
-                        Object.entries(CONFIG.DND5E.actorSizes).find(x => x[1] == value)[0] == x.system.traits.size
+                        Object.entries(CONFIG.DND5E.actorSizes).find(x => x[1].label === value)[0] === x.system.traits.size
                     ).length > 0;
                 }
                 return false;
@@ -178,7 +178,7 @@ export default class Dnd5e {
         if (selectedResistances?.length > 0) {
             availableActors = availableActors.filter(x => {
                 if (x.system?.traits?.dr != undefined) {
-                    return selectedResistances.filter(value => x.system.traits.dr.value.includes(value)).length > 0;
+                    return selectedResistances.filter(value => x.system.traits.dr.value.has(value)).length > 0;
                 }
                 return false;
             });
@@ -187,7 +187,7 @@ export default class Dnd5e {
         if (selectedImmunities?.length > 0) {
             availableActors = availableActors.filter(x => {
                 if (x.system?.traits?.di != undefined) {
-                    return selectedImmunities.filter(value => x.system.traits.di.value.includes(value)).length > 0;
+                    return selectedImmunities.filter(value => x.system.traits.di.value.has(value)).length > 0;
                 }
                 return false;
             });
@@ -196,7 +196,7 @@ export default class Dnd5e {
         if (selectedVulnerabilities?.length > 0) {
             availableActors = availableActors.filter(x => {
                 if (x.system?.traits?.dv != undefined) {
-                    return selectedVulnerabilities.filter(value => x.system.traits.dv.value.includes(value)).length > 0;
+                    return selectedVulnerabilities.filter(value => x.system.traits.dv.value.has(value)).length > 0;
                 }
                 return false;
             });
@@ -207,7 +207,7 @@ export default class Dnd5e {
 
     getActorSource(actor, skipDetails) {
         if (actor.system.details.source && !skipDetails) {
-            return actor.system.details.source.split('pg')[0];
+            return actor.system.details.source.label;
         }
 
         let nonCompendiumSourceType = game.settings.get("vue-encounter-builder", "nonCompendiumSourceType");

--- a/vue/EncounterBuilder.vue
+++ b/vue/EncounterBuilder.vue
@@ -258,8 +258,8 @@ export default {
     },
     addActor: function (actor) {
       if (actor.encounterScore > 0) {
-        let toPush = duplicate(actor);
-        toPush.id = randomID(16);
+        let toPush = foundry.utils.duplicate(actor);
+        toPush.id = foundry.utils.randomID(16);
         this.selectedActors.push(actor);
       }
     },
@@ -351,7 +351,7 @@ export default {
     availableActors() {
       let availableActors = this.actors;
 
-      let filters = duplicate(this.filters);
+      let filters = foundry.utils.duplicate(this.filters);
       filters["selectedName"] = this.selectedName;
       filters["selectedSources"] = this.selectedSources;
 
@@ -453,7 +453,7 @@ export default {
       let availableActors = this.actors;
 
       // We don't  use this.availableActors because that filters by level, and we always want the histogram to be all levels available
-      let filters = duplicate(this.filters);
+      let filters = foundry.utils.duplicate(this.filters);
       filters["selectedName"] = this.selectedName;
       filters["selectedSources"] = this.selectedSources;
       availableActors = this.system.filterAvailableActors(

--- a/vue/components/dnd5e/dnd5e-actor.vue
+++ b/vue/components/dnd5e/dnd5e-actor.vue
@@ -24,7 +24,7 @@
             :key="tag">{{tag}}</li>
         </ul>
 
-        <small class="actor-source">{{ actor.system.details.source }}</small>
+        <small class="actor-source">{{ actor.system.details.source.label }}</small>
       </section>
 
       <div class="actor-image" v-if="actor.img !== 'icons/svg/mystery-man.svg'">


### PR DESCRIPTION
Hello,

With the small debacle regarding the Warpgate module (see [here](https://www.reddit.com/r/FoundryVTT/comments/1dmuafe/rip_warp_gate/) ), the fact that it didn't work in v12, and the relatively small use case you made of it (only using it to spawn monsters), I took the liberty to swap it with the Portal lib module by theripper93, which is actively maintained and already supported in v12.

In addition to that, I made some fixes to the D&D5 model that reflect the changes made in that system with their latest major update and a few fixes to deprecation warnings that were added with v12.

It's not exhaustive, there are still some error messages in the console with D&D5 when the builder tries to render empty lists, but for now it loads the monsters, allows for encounter building and monster spawning, and it doesn't crashes, so that's good.