### PR TITLE
Add 13 Age 2e encounter balance

### DIFF
--- a/scripts/thirteenth-age.mjs
+++ b/scripts/thirteenth-age.mjs
@@ -134,7 +134,7 @@ export default class ThirteenthAge {
 
         let size = 'normal';
         if (enemy.system != undefined && enemy.system.details != undefined && enemy.system.details.size != undefined && enemy.system.details.size != '') {
-            size = enemy.system.details.size.value.toLowerCase();
+            size = enemy.system.details.strength.value.toLowerCase();
         }
         let sizeToColumn = {
             "weakling": 0,
@@ -188,7 +188,7 @@ export default class ThirteenthAge {
 
         let size = 'normal';
         if (enemy.system != undefined && enemy.system.details != undefined && enemy.system.details.size != undefined && enemy.system.details.size != '') {
-            size = enemy.system.details.size.value.toLowerCase();
+            size = enemy.system.details.strength.value.toLowerCase()
         }
 
         let sizeToColumn = {

--- a/scripts/thirteenth-age.mjs
+++ b/scripts/thirteenth-age.mjs
@@ -188,7 +188,7 @@ export default class ThirteenthAge {
 
         let size = 'normal';
         if (enemy.system != undefined && enemy.system.details != undefined && enemy.system.details.size != undefined && enemy.system.details.size != '') {
-            size = enemy.system.details.strength.value.toLowerCase()
+            size = enemy.system.details.strength.value.toLowerCase();
         }
 
         let sizeToColumn = {

--- a/vue/components/13th-age/thirteenth-age-encounter-summary.vue
+++ b/vue/components/13th-age/thirteenth-age-encounter-summary.vue
@@ -30,7 +30,16 @@ export default {
     maxEncounterScore() {
       let max = this.partyinfo.numberOfPartyMembers;
 
-      if (this.encountersettings.selectedChallenge == undefined) this.encountersettings.selectedChallenge = "Normal";
+      if (game.settings.get("archmage", "secondEdition")) {
+        // Using Second edition Gamma battle balance
+        if (max > 3) {
+          max = 5 + (max - 4)*2
+        }
+      }
+
+      if (this.encountersettings.selectedChallenge == undefined) {
+        this.encountersettings.selectedChallenge = "Normal";
+      }
 
       if (this.encountersettings.selectedChallenge.toLowerCase() == "double strength") {
         max *= 2;
@@ -38,6 +47,7 @@ export default {
       else if (this.encountersettings.selectedChallenge.toLowerCase() == "killer") {
         max *= 3;
       }
+      
       return max;
     },
   },


### PR DESCRIPTION
A small PR with a fix following a recent 13th Age system update that migrated monster "size" to strength, as well as a change to the encounter balance calculation when the 2E beta option is enabled for the system (a higher monster score per player when 4 or more PCs are present)